### PR TITLE
Feature: Add --hook

### DIFF
--- a/debian/debpic.install
+++ b/debian/debpic.install
@@ -8,3 +8,4 @@ debpic/debpic-completion.bash => /usr/share/bash-completion/completions/debpic
 debpic/debpic.conf => /etc/debpic/debpic.conf
 debpic/Dockerfile => usr/share/debpic/Dockerfile
 debpic/debpic.py => usr/bin/debpic
+debpic/hooks/ /etc/debpic/

--- a/debpic/Dockerfile
+++ b/debpic/Dockerfile
@@ -121,3 +121,6 @@ RUN apt-get update && \
     mk-build-deps /tmp/control && \
     apt-get install ./*build-deps*.deb
 # ---------------------------------------------------------------------------- #
+
+COPY debpic_hoo[k] /usr/bin/hook
+CMD ["bash", "-c", "if [[ -x /usr/bin/hook ]]; then source /usr/bin/hook; fi && bash"]

--- a/debpic/Documentation/debpic.manpage.md
+++ b/debpic/Documentation/debpic.manpage.md
@@ -48,6 +48,10 @@ The environment is composed from:
 
 : Open an interactive terminal to the container.
 
+**-hk**, **--hook**  
+
+: Select a bash script stored at /etc/debpic/hooks/\<SCRIPT\> to run after the container starts.
+
 **-vs**, **--vscode**  
 
 : Open repository using Visual Studio Code Dev Container (https://code.visualstudio.com/docs/devcontainers/containers).
@@ -81,6 +85,11 @@ _/etc/debpic/sources.list.d/default.sources_
 _/etc/debpic/preferences.d/*.pref_
 
 : This is where debpic stores the list of preference control files for APT.  The contents of \<SOURCE\>.pref are copied to /etc/apt/preferences/debpic.pref within the container before any build dependencies are selected. The choice of which file is selected can be controlled using the --sources option.
+
+
+_/etc/debpic/hooks/*_
+
+: This is where debpic stores bash scripts which can be invoked after the container is started. The choice of which file is selected can be controlled using the `--hook` option.
 
 
 _/usr/share/debpic/Dockerfile_

--- a/debpic/debpic-completion.bash
+++ b/debpic/debpic-completion.bash
@@ -14,7 +14,7 @@ _debpic_complete() {
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
-  opts="--help --no-cache --distribution --local-repository --sources --extra-pkg --destination --interactive --vscode --delete-images -- "
+  opts="--help --no-cache --distribution --local-repository --sources --extra-pkg --destination --interactive --hook --vscode --delete-images -- "
 
 
   instances_of_double_dash=0
@@ -59,6 +59,9 @@ _debpic_complete() {
     if [[ "$word" == "--interactive" || "$word" == "-i" ]]; then
       opts=$(echo "$opts" | sed 's/--help//;s/--delete-images//;s/--interactive//;s/-- //;s/--vscode//')
     fi
+    if [[ "$word" == "--hook" || "$word" == "-hk" ]]; then
+      opts=$(echo "$opts" | sed 's/--help//;s/--delete-images//;s/--hook//')
+    fi
     if [[ "$word" == "--vscode" || "$word" == "-vs" ]]; then
       opts=$(echo "$opts" | sed 's/--help//;s/--delete-images//;s/--vscode//;s/-- //;s/--interactive//;s/--no-cache//;s/--destination//;')
     fi
@@ -92,6 +95,17 @@ _debpic_complete() {
       return 0
       ;;
     -dst|--destination)
+      return 0
+      ;;
+    -hk|--hook)
+      # Completing source file names without extensions in /etc/debpic/sources.list.d/
+      local source_dir="/etc/debpic/hooks/"
+      local files=$(compgen -f -- "${source_dir}${cur}")
+      if [ -n "${files}" ]; then
+        COMPREPLY=( $(basename -a ${files}))
+      else
+        COMPREPLY=()  # No matching files, so no completions
+      fi
       return 0
       ;;
     *)

--- a/debpic/debpic_test.py
+++ b/debpic/debpic_test.py
@@ -48,13 +48,13 @@ class Test:
         uut.run_container("test_name")
         assert (
             self.cli_commands.pop(0)
-            == "docker run --mount type=bind,src=${PWD},dst=/workspaces/code --mount type=volume,src=ccache_volume,dst=/home/docker/.cache/ccache --user 1000:$(id -g 1000) --network host --tty --rm --env DEB_BUILD_OPTIONS=\"\"  test_name /bin/bash -c 'dpkg-buildpackage  && mv-debs && dpkg-buildpackage --target=clean'"
+            == "docker run --mount type=bind,src=${PWD},dst=/workspaces/code --mount type=volume,src=ccache_volume,dst=/home/docker/.cache/ccache --user 1000:$(id -g 1000) --network host --tty --rm --env DEB_BUILD_OPTIONS=\"\"  test_name /bin/bash -c 'if [[ -x /usr/bin/hook ]]; then source /usr/bin/hook; fi && dpkg-buildpackage  && mv-debs && dpkg-buildpackage --target=clean'"
         )
 
         uut.run_container("test_name", "echo I'm a test command")
         assert (
             self.cli_commands.pop(0)
-            == "docker run --mount type=bind,src=${PWD},dst=/workspaces/code --mount type=volume,src=ccache_volume,dst=/home/docker/.cache/ccache --user 1000:$(id -g 1000) --network host --tty --rm --env DEB_BUILD_OPTIONS=\"\"  test_name /bin/bash -c 'echo I'm a test command'"
+            == "docker run --mount type=bind,src=${PWD},dst=/workspaces/code --mount type=volume,src=ccache_volume,dst=/home/docker/.cache/ccache --user 1000:$(id -g 1000) --network host --tty --rm --env DEB_BUILD_OPTIONS=\"\"  test_name /bin/bash -c 'if [[ -x /usr/bin/hook ]]; then source /usr/bin/hook; fi && echo I'm a test command'"
         )
 
         uut.run_container("test_name", "", "", "--interactive")

--- a/debpic/hooks/gopath
+++ b/debpic/hooks/gopath
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# GOPATH setup script
+#
+# This script will allow the developer to run go tools such as "go test ./..." or "go build"
+# without having to invoke dpkg-buildpackage.
+
+# Turn off Go modules
+go env -w GO111MODULE=off
+
+# Set the path to the location where debian packages install go code
+export GOPATH=/usr/share/gocode/
+echo "export GOPATH=/usr/share/gocode/" >> ~/.bashrc
+
+# Check DH_GOPKG is set before progressing
+grep -q "^export DH_GOPKG" debian/rules || { echo "Error: DH_GOPKG is not set in the file."; }
+
+# Determine DH_GOPKG
+DH_GOPKG=$(grep -Po '(?<=export DH_GOPKG := ).*' debian/rules)
+
+# Create parent directories to DH_GOPKG location.
+sudo mkdir -p /usr/share/gocode/src/$DH_GOPKG
+
+# Remove last directory as it will be symbolic linked and if it's not removed ln will complain/
+sudo rm -r /usr/share/gocode/src/$DH_GOPKG
+
+# Symbolic link current directory to DH_GOPKG location.
+sudo ln -s $(pwd) /usr/share/gocode/src/$DH_GOPKG


### PR DESCRIPTION
Allow the user to specify a hook to run after the image is built.

The hooks will be stored in /etc/debpic/hooks

The user will specify the hook in a similar manner to how the sources are specified.

Add initial gopath hook which allows devs to run "go test ./...", etc.

1. The python will copy the hook file (if it exists) to the build context.

2. The dockerfile will copy the (moved) hook to the image (if it exists)
```
COPY hoo[k] /usr/bin/hook
```

3. All modes (interactive, command specified & package commands) will check if the hook exists and execute it if it does. I'm currently executing the hook by using source so the bash exports are maintained in the shell (for example export GOPATH=/usr/share/gocode/). Unfortunately this means the scripts are limited to bash. This could be revisited.
```
if [[ -x /usr/bin/hook ]]; then source /usr/bin/hook; fi
```